### PR TITLE
fix post validation bug for post_types != 1

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,7 @@ after_initialize do
       ## This should be replaced with a :voted? property in TopicUser - but how to do this in a plugin?
       def user_has_voted(topic, user)
         return nil if !user
-        
+
         PostAction.exists?(post_id: topic.posts.map(&:id),
                            user_id: user.id,
                            post_action_type_id: PostActionType.types[:vote])
@@ -60,7 +60,7 @@ after_initialize do
   end
 
   DiscourseEvent.on(:post_created) do |post, opts, user|
-    if !post.is_first_post? && QAHelper.qa_enabled(post.topic)
+    if !post.is_first_post? && QAHelper.qa_enabled(post.topic) && post.post_type == 1
       post.sort_order = Topic.max_sort_order
       post.save!
     end


### PR DESCRIPTION
This pull request adds a guard clause to make sure the post is a "content" type post. I ran into a problem in my own plugin where posts of "administrative" types failed the validation from `.save!` when put through the same methods. 

Referenced here:
https://meta.discourse.org/t/ember-error-on-unpinning-archiving-topic/56253/5