### PR TITLE
create boilerplate qa badges based on individual post upvotes and total upvotes

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -80,4 +80,140 @@ after_initialize do
   end
 
   add_to_serializer(:basic_category, :qa_enabled) { object.custom_fields["qa_enabled"] }
+
+  #create qa specific badges
+  upvotes_id = BadgeGrouping.find_or_create_by(name: "Upvotes", position: 1).id
+  badge_type_gold_id = BadgeType.find_by(name: "Gold").id
+  badge_type_silver_id = BadgeType.find_by(name: "Silver").id
+  badge_type_bronze_id = BadgeType.find_by(name: "Bronze").id
+
+  professor = {
+    name: "Professor",
+    description: "Received more than 100 total upvotes",
+    badge_type_id: badge_type_gold_id,
+    allow_title: true,
+    multiple_grant: false,
+    icon: "fa-graduation-cap",
+    listable: true,
+    target_posts: false,
+    query:
+    "SELECT count(*), r.username Liked, r.id user_id, current_timestamp granted_at\nFROM post_actions pa\nINNER JOIN posts p on p.id=pa.post_id /* Get post details */\nINNER JOIN users r on r.id=p.user_id /* The user who made the post that was liked */\nWHERE pa.post_action_type_id=5 /* upvote type */\nGROUP BY Liked, r.id\nHAVING count(*) >= 100 /* Change to suit */\nORDER BY count(*) DESC",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 0,
+    show_posts: false,
+    system: false,
+    image: "fa-graduation-cap",
+    long_description: ""
+  }
+
+  teacher = {
+    name: "Teacher",
+    description: "Received more than 20 total upvotes",
+    badge_type_id: badge_type_silver_id,
+    allow_title: true,
+    multiple_grant: false,
+    icon: "fa-graduation-cap",
+    listable: true,
+    target_posts: false,
+    query:
+    "SELECT count(*), r.username Liked, r.id user_id, current_timestamp granted_at\nFROM post_actions pa\nINNER JOIN posts p on p.id=pa.post_id /* Get post details */\nINNER JOIN users r on r.id=p.user_id /* The user who made the post that was liked */\nWHERE pa.post_action_type_id=5 /* upvote type */\nGROUP BY Liked, r.id\nHAVING count(*) >= 20 /* Change to suit */\nORDER BY count(*) DESC",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 0,
+    show_posts: false,
+    system: false,
+    image: "fa-graduation-cap",
+    long_description: ""
+  }
+
+  tutor = {
+    name: "Tutor",
+    description: "Received more than 10 total upvotes",
+    badge_type_id: badge_type_bronze_id,
+    allow_title: true,
+    multiple_grant: false,
+    icon: "fa-graduation-cap",
+    listable: true,
+    target_posts: false,
+    query:
+    "SELECT count(*), r.username Liked, r.id user_id, current_timestamp granted_at\nFROM post_actions pa\nINNER JOIN posts p on p.id=pa.post_id /* Get post details */\nINNER JOIN users r on r.id=p.user_id /* The user who made the post that was liked */\nWHERE pa.post_action_type_id=5 /* upvote type */\nGROUP BY Liked, r.id\nHAVING count(*) >= 10 /* Change to suit */\nORDER BY count(*) DESC",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 0,
+    show_posts: false,
+    system: false,
+    image: "fa-graduation-cap",
+    long_description: ""
+  }
+
+  goal = {
+    name: "Goooal!!!",
+    description: "Received one upvote for an answer",
+    badge_type_id: badge_type_bronze_id,
+    allow_title: false,
+    multiple_grant: true,
+    icon: "fa-futbol-o",
+    listable: true,
+    target_posts: false,
+    query: "SELECT p.user_id, p.id post_id, p.updated_at granted_at\nFROM badge_posts p\nWHERE p.vote_count >= 1 AND\n(:backfill OR p.id IN (:post_ids) )",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 1,
+    show_posts: true,
+    system: false,
+    image: "fa-futbol-o",
+    long_description: nil
+  }
+
+  double_play = {
+    name: "Double Play",
+    description: "Received two upvotes for an answer",
+    badge_type_id: badge_type_silver_id,
+    allow_title: false,
+    multiple_grant: true,
+    icon: "fa-futbol-o",
+    listable: true,
+    target_posts: false,
+    query: "SELECT p.user_id, p.id post_id, p.updated_at granted_at\nFROM badge_posts p\nWHERE p.vote_count >= 2 AND\n(:backfill OR p.id IN (:post_ids) )",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 1,
+    show_posts: true,
+    system: false,
+    image: "fa-futbol-o",
+    long_description: nil
+  }
+
+  hat_trick = {
+    name: "Hat-trick",
+    description: "Received three upvotes for an answer",
+    badge_type_id: badge_type_gold_id,
+    allow_title: false,
+    multiple_grant: true,
+    icon: "fa-futbol-o",
+    listable: true,
+    target_posts: false,
+    query: "SELECT p.user_id, p.id post_id, p.updated_at granted_at\nFROM badge_posts p\nWHERE p.vote_count >= 3 AND\n(:backfill OR p.id IN (:post_ids) )",
+    enabled: true,
+    auto_revoke: false,
+    badge_grouping_id: upvotes_id,
+    trigger: 1,
+    show_posts: true,
+    system: false,
+    image: "fa-futbol-o",
+    long_description: nil
+  }
+
+  Badge.find_or_create_by(professor)
+  Badge.find_or_create_by(teacher)
+  Badge.find_or_create_by(tutor)
+  Badge.find_or_create_by(goal)
+  Badge.find_or_create_by(double_play)
+  Badge.find_or_create_by(hat_trick)
 end


### PR DESCRIPTION
Hey Angus,

I did some preliminary work on creating badges. I made some "fixtures" in `plugin.rb`. There is likely a more preferred way to make fixtures for a plugin, which you may have more knowledge of than me. I'm happy to change it to that format. 

I was able to test them on development by going to `http://localhost:3001/sidekiq/scheduler` and running `ProcessBadgeBacklog` and `BadgeGrant `. I had to scale down the queries from 100 and 20 etc to 1, 2, or 3.

Also, I ran into a weird problem in the Admin interface when trying to update one of these fixture badges. It always gave me an `unpermitted parameter` error. It didn't effect the job running/badge giving, but its another thing to fix.

```
I, [2017-02-12T16:23:03.430406 #7826]  INFO -- :   Parameters: {"allow_title"=>"true", "multiple_grant"=>"false", "listable"=>"true", "auto_revoke"=>"false", "enabled"=>"true", "show_posts"=>"false", "target_posts"=>"false", "name"=>"Teacher", "description"=>"More than 20 total upvotes.", "long_description"=>"", "icon"=>"fa-graduation-cap", "image"=>"fa-graduation-cap", "query"=>"SELECT count(*), r.username Liked, r.id user_id, current_timestamp granted_at\nFROM post_actions pa\nINNER JOIN posts p on p.id=pa.post_id /* Get post details */\nINNER JOIN users r on r.id=p.user_id /* The user who made the post that was liked */\nWHERE pa.post_action_type_id=5 /* upvote type */\nGROUP BY Liked, r.id\nHAVING count(*) >= 20 /* Change to suit */\nORDER BY count(*) DESC", "badge_grouping_id"=>"6", "trigger"=>"0", "badge_type_id"=>"2", "id"=>"101"}
D, [2017-02-12T16:23:03.432144 #7826] DEBUG -- :   UserVisit Load (0.6ms)  SELECT  "user_visits".* FROM "user_visits" WHERE "user_visits"."user_id" = 1 AND "user_visits"."visited_at" = '2017-02-12' LIMIT 1  [["user_id", 1], ["visited_at", Sun, 12 Feb 2017]]
D, [2017-02-12T16:23:03.438788 #7826] DEBUG -- :   SQL (0.9ms)  UPDATE "users" SET "last_seen_at" = '2017-02-12 23:23:03.425166' WHERE "users"."id" = 1  [["id", 1]]
D, [2017-02-12T16:23:03.441849 #7826] DEBUG -- :   SQL (1.4ms)  UPDATE "notifications" SET "read" = 't' WHERE "notifications"."user_id" = 1 AND "notifications"."read" = 'f' AND "notifications"."id" = 81  [["user_id", 1], ["read", false]]
D, [2017-02-12T16:23:03.445639 #7826] DEBUG -- :   Badge Load (1.3ms)  SELECT  "badges".* FROM "badges" WHERE "badges"."id" = 101 LIMIT 1  [["id", "101"]]
D, [2017-02-12T16:23:03.447732 #7826] DEBUG -- :    (0.5ms)  BEGIN
D, [2017-02-12T16:23:03.449530 #7826] DEBUG -- : Unpermitted parameter: id
```

I set the badges category to be the first position, which ideally should be customizable.

<img width="1126" alt="screen shot 2017-02-12 at 4 25 33 pm" src="https://cloud.githubusercontent.com/assets/5934106/22867176/0a1014e4-f140-11e6-9e41-c349338b161f.png">
<img width="1127" alt="screen shot 2017-02-12 at 4 25 19 pm" src="https://cloud.githubusercontent.com/assets/5934106/22867178/0a10b6d8-f140-11e6-8dda-28d563fbcb54.png">
<img width="390" alt="screen shot 2017-02-12 at 4 25 07 pm" src="https://cloud.githubusercontent.com/assets/5934106/22867177/0a107a4c-f140-11e6-9ac4-72c6c612e705.png">

There is more work to do on this, but this should be a starting point.

-Jeffrey
